### PR TITLE
chore: release

### DIFF
--- a/putty_storage/CHANGELOG.md
+++ b/putty_storage/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/simon-rechermann/putty_rs_async/releases/tag/putty_storage-v0.1.0) - 2026-04-13
+
+### Added
+
+- extract putty storage and add deploy github releases ([#11](https://github.com/simon-rechermann/putty_rs_async/pull/11))


### PR DESCRIPTION



## 🤖 New release

* `putty_storage`: 0.1.0
* `putty-rs`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `putty_storage`

<blockquote>

## [0.1.0](https://github.com/simon-rechermann/putty_rs_async/releases/tag/putty_storage-v0.1.0) - 2026-04-13

### Added

- extract putty storage and add deploy github releases ([#11](https://github.com/simon-rechermann/putty_rs_async/pull/11))
</blockquote>

## `putty-rs`

<blockquote>

## [0.1.1](https://github.com/simon-rechermann/putty_rs_async/compare/putty-rs-v0.1.0...putty-rs-v0.1.1) - 2026-04-13

### Added

- extract putty storage and add deploy github releases ([#11](https://github.com/simon-rechermann/putty_rs_async/pull/11))

### Other

- Added better help messages and updated the docs ([#9](https://github.com/simon-rechermann/putty_rs_async/pull/9))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).